### PR TITLE
chore: unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,23 @@
 {
   "name": "@lunaticmuch/front-matter-manipulator",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lunaticmuch/front-matter-manipulator",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "async": "^3.2.4",
         "chalk": "^4.0.1",
-        "cli-spinner": "^0.2.7",
         "deepmerge": "^4.2.2",
         "documentation": "^14.0.0",
-        "flat": "^5.0.2",
         "glob": "^8.0.3",
         "gray-matter": "^4.0.3",
         "jest": "^29.0.1",
         "lodash": "^4.17.4",
-        "simple-autoloader": "^0.2.0",
         "yamljs": "^0.3.0",
         "yargs": "^17.5.1"
       },
@@ -1528,13 +1525,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
-    "node_modules/cli-spinner": {
-      "version": "0.2.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1978,14 +1968,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/fs.realpath": {
@@ -6544,32 +6526,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "node_modules/simple-autoloader": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.1"
-      }
-    },
-    "node_modules/simple-autoloader/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8433,9 +8389,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
-    "cli-spinner": {
-      "version": "0.2.10"
-    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -8768,11 +8721,6 @@
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
       }
-    },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
     },
     "fs.realpath": {
       "version": "1.0.0"
@@ -12089,27 +12037,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "simple-autoloader": {
-      "version": "0.2.0",
-      "requires": {
-        "glob": "^7.1.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lunaticmuch/front-matter-manipulator",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A utility for parsing and manipulating documents with Front Matter",
   "directories": {
     "lib": "lib"
@@ -27,15 +27,12 @@
     "@iarna/toml": "^2.2.5",
     "async": "^3.2.4",
     "chalk": "^4.0.1",
-    "cli-spinner": "^0.2.7",
     "deepmerge": "^4.2.2",
     "documentation": "^14.0.0",
-    "flat": "^5.0.2",
     "glob": "^8.0.3",
     "gray-matter": "^4.0.3",
     "jest": "^29.0.1",
     "lodash": "^4.17.4",
-    "simple-autoloader": "^0.2.0",
     "yamljs": "^0.3.0",
     "yargs": "^17.5.1"
   },


### PR DESCRIPTION
Remove the following which are not used:

- `flat` 
- `simple-autoloader`
- `cli-spinner` 